### PR TITLE
Feature: Lossy Beam Splitter

### DIFF
--- a/interferometer/main.py
+++ b/interferometer/main.py
@@ -33,7 +33,7 @@ class Beamsplitter:
                 self.phi
                 )
         else:
-            repr = "\n Beam splitter between modes {} and {}: \n Theta angle: {:.2f} \n Phase: {:.2f} \n Loss parameter: {:.2f}".format(
+            repr = "\n Beam splitter between modes {} and {}: \n Theta angle: {:.2f} \n Phase: {:.2f} \n Alpha: {:.2f}".format(
                 self.mode1,
                 self.mode2,
                 self.theta,
@@ -52,6 +52,12 @@ class Interferometer:
     Clements, William R., et al. "Optimal design for universal multiport interferometers." Optica 3.12 (2016): 1460-1465.
     This transformation is parametrized by BS[2] (theta) which determines the beam splitter reflectivity, 
     and by BS[3] (phi). The interferometer also contains a list of output phases described by output_phases.
+    Additionally, if the loss parameter alpha_i has been set to a value other than 0 for the beam splitter BS_i, 
+    it will be lossy. 
+    This is implemented by multiplying the elements different from 1 in the transformation matrix T_i by e^{-alpha_i} 
+    for each lossy beam splitter.
+    This optional functionality allows to conduct experiments on the fidelity of the different meshes with respect to the loss parameter,
+    as described in the later sections of the paper (5).
     """
 
     def __init__(self):
@@ -98,11 +104,15 @@ class Interferometer:
         U = np.eye(N, dtype=np.complex128)
 
         for BS in self.BS_list:
+            if BS.alpha == 0.0:
+                lossTerm = 1
+            else:
+                lossTerm = np.exp(-BS.alpha)
             T = np.eye(N, dtype=np.complex128)
-            T[BS.mode1 - 1, BS.mode1 - 1] = np.exp(1j * BS.phi) * np.cos(BS.theta)
-            T[BS.mode1 - 1, BS.mode2 - 1] = -np.sin(BS.theta)
-            T[BS.mode2 - 1, BS.mode1 - 1] = np.exp(1j * BS.phi) * np.sin(BS.theta)
-            T[BS.mode2 - 1, BS.mode2 - 1] = np.cos(BS.theta)
+            T[BS.mode1 - 1, BS.mode1 - 1] = lossTerm * np.exp(1j * BS.phi) * np.cos(BS.theta)
+            T[BS.mode1 - 1, BS.mode2 - 1] = lossTerm * -np.sin(BS.theta)
+            T[BS.mode2 - 1, BS.mode1 - 1] = lossTerm * np.exp(1j * BS.phi) * np.sin(BS.theta)
+            T[BS.mode2 - 1, BS.mode2 - 1] = lossTerm * np.cos(BS.theta)
             U = np.matmul(T,U)
 
         while np.size(self.output_phases) < N:  # Autofill for users who don't want to bother with output phases
@@ -135,8 +145,9 @@ class Interferometer:
             plt.plot((x+0.3, x+1), (N - BS.mode2, N - BS.mode1), lw=1, color="blue")
             plt.plot((x+0.4, x+0.9), (N - (BS.mode2 + BS.mode1)/2, N - (BS.mode2 + BS.mode1)/2), lw=1, color="blue")
             reflectivity = "{:2f}".format(np.cos(BS.theta)**2)
+            loss = "{:2f}".format(np.exp(-BS.alpha))
             plt.text(x+0.9, N + 0.05 - (BS.mode2 + BS.mode1)/2, reflectivity[0:3], color="green", fontsize=7)
-
+            plt.text(x+0.2, N + 0.05 - (BS.mode2 + BS.mode1)/2, loss[0:3], color="black", fontsize=7)
             plt.plot((x+0.15, x+0.15), (N+0.3-(BS.mode2 + BS.mode1)/2., N+0.7-(BS.mode2 + BS.mode1)/2.), lw=1, color="blue")
             circle = plt.Circle((x+0.15, N+0.5-(BS.mode2 + BS.mode1)/2.), 0.1, fill=False)
             plt.gca().add_patch(circle)
@@ -169,6 +180,7 @@ class Interferometer:
 
 
         plt.text(max_x/2, -0.7, "green: BS reflectivity", color="green", fontsize=10)
+        plt.text(max_x/2, -1.05, "black: BS loss", color="black", fontsize=10)
         plt.text(max_x/2, -1.4, "red: phase shift", color="red", fontsize=10)
         plt.text(-1, N-0.3, "Light in", fontsize=10)
         plt.text(max_x+0.5, N-0.3, "Light out", fontsize=10)

--- a/interferometer/main.py
+++ b/interferometer/main.py
@@ -6,29 +6,40 @@ class Beamsplitter:
 
     The matrix describing the mode transformation is:
 
-        e^{iphi}*cos(theta)     -sin(theta)
-        e^{iphi}*sin(theta)     cos(theta)
+    e^{-alpha} * [[e^{iphi}*cos(theta)     -sin(theta)],
+                  [e^{iphi}*sin(theta)     cos(theta)]]
 
     Args:
         mode1 (int): the index of the first mode (the first mode is mode 1)
         mode2 (int): the index of the second mode
         theta (float): the beam splitter angle
         phi (float): the beam splitter phase
+        alpha (float): the beam splitter loss parameter (default 0)
     """
 
-    def __init__(self, mode1, mode2, theta, phi):
+    def __init__(self, mode1, mode2, theta, phi, alpha=0.0):
         self.mode1 = mode1
         self.mode2 = mode2
         self.theta = theta
         self.phi = phi
+        self.alpha = alpha
 
     def __repr__(self):
-        repr = "\n Beam splitter between modes {} and {}: \n Theta angle: {:.2f} \n Phase: {:.2f}".format(
-            self.mode1,
-            self.mode2,
-            self.theta,
-            self.phi
-            )
+        if self.alpha == 0.0:
+            repr = "\n Beam splitter between modes {} and {}: \n Theta angle: {:.2f} \n Phase: {:.2f}".format(
+                self.mode1,
+                self.mode2,
+                self.theta,
+                self.phi
+                )
+        else:
+            repr = "\n Beam splitter between modes {} and {}: \n Theta angle: {:.2f} \n Phase: {:.2f} \n Loss parameter: {:.2f}".format(
+                self.mode1,
+                self.mode2,
+                self.theta,
+                self.phi,
+                self.alpha
+                )
         return repr
 
 

--- a/tests/test_interferometer.py
+++ b/tests/test_interferometer.py
@@ -1,7 +1,11 @@
 import numpy as np
 from unittest import TestCase
+import sys
+import os
 
-from interferometer import random_unitary, triangle_decomposition, square_decomposition
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from interferometer.main import Interferometer, Beamsplitter, triangle_decomposition, square_decomposition, random_unitary
 
 class TestInterferometer(TestCase):
 
@@ -14,4 +18,29 @@ class TestInterferometer(TestCase):
         U = random_unitary(5)
         I = square_decomposition(U)
         self.assertTrue(abs(np.max(I.calculate_transformation() - U)) < 1e-14)
-    
+
+    def test_loss(self):
+        U = random_unitary(10)
+        I = square_decomposition(U)
+        U_pure = I.calculate_transformation()
+        for bs in I.BS_list:
+            bs.alpha = 3.0
+
+        U_loss = I.calculate_transformation()
+        input = np.ones(10) * (1/np.sqrt(10))
+
+        output_loss = U_loss @ input
+        output_ideal = U_pure @ input
+        self.assertTrue(np.sum(np.square(np.abs(output_loss))) < np.sum(np.square(np.abs(output_ideal))))
+
+        
+
+def main():
+    test = TestInterferometer()
+    test.test_square_interferometer()
+    test.test_triangle_interferometer()
+    test.test_loss()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We introduced a loss parameter `alpha` to the `BeamSplitter` class to enable studies on Fidelity, simulating realistic experimental conditions as described in:
- [Reck et al., Phys. Rev. Lett. 73, 58 (1994)](https://doi.org/10.1103/PhysRevLett.73.58)
- [Clements et al., Optica 3, 1460 (2016)](https://doi.org/10.1364/OPTICA.3.001460)

**Backward Compatibility**
This implementation is consistent with the existing codebase. The `alpha` parameter defaults to `0`, ensuring no modifications to the ideal transmission matrices of the existing architectures.

**Implementation Details**
The loss is modeled mathematically as $e^{-\alpha}$. Specifically, we:
- Updated the `BeamSplitter` interface to accept the `alpha` parameter and adjusted the `__repr__` method accordingly.
- Modified the `Interferometer` class: updated the `draw` method to display the loss parameter for each BS, and adapted `calculate_transformation` to apply the loss coefficient to the specific modes passing through the corresponding BS.
- Added a dedicated test to verify that the output power is correctly lowered when losses are introduced.

*(Developed in collaboration with @DanieleConfalonieri)*